### PR TITLE
🐛 Fix : 네비게이션 이동시 깜박임 현상 수정, Accessiblity 오류 수정

### DIFF
--- a/app/accessibility/page.tsx
+++ b/app/accessibility/page.tsx
@@ -1,3 +1,6 @@
+// app/accessibility/page.tsx
+'use client';
+
 import React from 'react';
 import Header from '../../components/Header';
 import useAccessibilityStore from '../../store/accessibilityStore';

--- a/components/Drawer.tsx
+++ b/components/Drawer.tsx
@@ -8,51 +8,32 @@ import useAccessibilityStore from '../store/accessibilityStore';
 interface DrawerProps {
   isOpen: boolean;
   onClose: () => void;
+  disableAnimation: boolean;
 }
 
-const Drawer: React.FC<DrawerProps> = ({ isOpen, onClose }) => {
+const Drawer: React.FC<DrawerProps> = ({ isOpen, onClose, disableAnimation }) => {
   const { accessibilityMode } = useAccessibilityStore();
 
-  // "즉시 닫기"를 위한 state
-  const [instantClose, setInstantClose] = useState(false);
-
-  // variants 정의:
-  //  - closed: 슬라이드 애니메이션으로 닫힘
-  //  - open: 슬라이드 애니메이션으로 열림
-  //  - instantClosed: 애니메이션 없이 바로 사라짐
+  // variants: disableAnimation일 경우 transition을 0으로 적용
   const containerVariants = {
     open: {
       x: 95,
       opacity: 1,
       scale: 1,
-      transition: { 
-        type: 'spring', 
-        stiffness: 300, 
-        damping: 30 
-      },
+      transition: disableAnimation 
+        ? { duration: 0 } 
+        : { type: 'spring', stiffness: 300, damping: 30 },
     },
     closed: {
       x: 40,
       opacity: 0,
       scale: 0.95,
-      transition: { 
-        type: 'spring', 
-        stiffness: 300, 
-        damping: 30,
-        duration: 0.25, // 필요에 따라 조정
-      },
-    },
-    // 즉시 사라지는 상태
-    instantClosed: {
-      x: 40,
-      opacity: 0,
-      scale: 0.95,
-      transition: { duration: 0 }, // 0초!
+      transition: disableAnimation 
+        ? { duration: 0 } 
+        : { type: 'spring', stiffness: 300, damping: 30, duration: 0.25 },
     },
   };
 
-  // 어떤 카테고리를 클릭해도 즉시 닫히도록 하려면 아래 처리를 모든 Link에 공통 적용
-  // 만약 "SUPPORT"만 이렇게 하고 싶다면 조건문으로 분기해도 됨
   const categories = [
     { name: 'SUPPORT', path: '/help' },
     { name: 'TERMS', path: '/policies/terms-of-service' },
@@ -61,31 +42,22 @@ const Drawer: React.FC<DrawerProps> = ({ isOpen, onClose }) => {
     { name: 'COOKIES', path: '/policies/cookies' },
   ];
 
-  // 현재 animate 상태 결정
-  // - instantClose가 true 이면 instantClosed
-  // - 아니면, isOpen 이면 open, 아니면 closed
-  const currentVariant = instantClose ? 'instantClosed' : isOpen ? 'open' : 'closed';
-
   return (
     <motion.div
       variants={containerVariants}
       initial="closed"
-      animate={currentVariant}
+      animate={isOpen ? 'open' : 'closed'}
       className="absolute left-0 top-0 h-full flex items-center overflow-hidden"
     >
       <nav>
         <ul className="flex text-md space-x-9">
           {categories.map((cat) => (
-            <li
-              key={cat.name}
-              className={`${accessibilityMode ? 'underline' : ''}`}
-            >
+            <li key={cat.name} className={`${accessibilityMode ? 'underline' : ''}`}>
               <Link
                 href={cat.path}
                 onClick={() => {
-                  // 페이지 이동 시 즉시 닫히도록
-                  setInstantClose(true);
-                  onClose(); // 부모로부터 내려온 Drawer 닫기
+                  // 내비게이션 전에 애니메이션 끄기
+                  onClose();
                 }}
               >
                 {cat.name}

--- a/components/HamburgerMenu.scss
+++ b/components/HamburgerMenu.scss
@@ -1,56 +1,57 @@
-/* .menu-button는 기존 Tailwind 클래스와 별도로 패딩 15px를 적용 */
+/* HamburgerMenu.scss */
+
 .menu-button {
-  padding: 12px;
-  width: 48px;   /* 예시로 정사각형 크기 (필요에 따라 조정) */
-  height: 48px;
-  border-radius: 20px;
+  padding: 8px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50px;
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   cursor: pointer;
-
-  /* open 상태에서 아이콘 내부의 좌측 50%를 잘라내어 우측 절반만 보이도록 */
-  &.open .menu-button__icon {
-    border-radius: 9999px;
-    /* clip-path inset(상, 우, 하, 좌) – 좌측 50%는 감추기 */
-    clip-path: inset(0 0 0 17%);
-    // transition: clip-path 0.3s;
-    transition: none; 
-  }
 }
 
-/* 아이콘 컨테이너는 .menu-button 내부에 가운데 정렬 */
-.menu-button__icon {
-  position: relative;
+.menu-button.accessible {
+  background-color: #dadada;
+}
+
+/* 아이콘 wrapper: 내부 clip‑path 변화가 외부에 노출되지 않도록 */
+.menu-button__icon-wrapper {
   width: 100%;
   height: 100%;
-  /* 별도의 clip-path 기본값은 없으므로 전체가 보임 */
+  overflow: hidden;
 }
 
-/* 공통 막대 스타일 */
+/* 아이콘: 항상 동일한 clip-path 적용 */
+.menu-button__icon {
+  width: 100%;
+  height: 100%;
+  clip-path: inset(0 0 0 17%); /* 항상 좌측 17%는 가려진 상태 */
+  transition: none; /* clip-path 전환 효과 제거 */
+}
+
+/* 막대(bar) 스타일은 기존대로 애니메이션 적용 */
 .menu-button__bar {
   background-color: #000;
   border-radius: 9999px;
   height: 2px;
   position: absolute;
-  width: 16px;  /* 막대 길이 (필요에 따라 조정) */
+  width: 16px;
   left: 50%;
   transform: translateX(-50%);
-  transition: transform 0.3s;
+  transition: transform 0.2s;
 }
 
-/* 두 막대의 초기 위치: 중앙을 기준으로 위/아래로 배치 */
 .menu-button__bar--1 {
-  top: calc(50% - 4px);  /* 중앙보다 약간 위쪽 */
+  top: calc(50% - 4px);
 }
 .menu-button__bar--2 {
-  top: calc(50% + 3px);  /* 중앙보다 약간 아래쪽 */
+  top: calc(50% + 3px);
 }
 
-/* open 상태: 두 막대를 X자로 변환하고 좌측으로 약간 이동 */
+/* open 상태에서는 막대의 transform만 변경하여 X 아이콘을 만듦 */
 .menu-button.open .menu-button__bar--1 {
-  /* translateX(-50%) 기본에서 추가로 -6px를 더 왼쪽으로 이동하고, 약간 아래로, -45도 회전 */
   transform: translate(calc(-50% - 6px), 2px) rotate(-40deg);
 }
 .menu-button.open .menu-button__bar--2 {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,10 @@
-'use client';
+"use client";
 
-import React, { useState, MouseEvent, useEffect } from 'react';
-import { usePathname, useRouter } from 'next/navigation';
-import useAccessibilityStore from '../store/accessibilityStore';
-import Drawer from './Drawer';
-import { FiPlus, FiShoppingCart } from 'react-icons/fi';
+import React, { useState, MouseEvent, useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import useAccessibilityStore from "../store/accessibilityStore";
+import Drawer from "./Drawer";
+import { FiPlus, FiShoppingCart } from "react-icons/fi";
 import "./HamburgerMenu.scss"; // SCSS 파일 import
 
 const Header: React.FC = () => {
@@ -12,16 +12,22 @@ const Header: React.FC = () => {
   const pathname = usePathname();
   const { accessibilityMode } = useAccessibilityStore();
 
-  // 메인 페이지인지 여부
-  const isMainPage = pathname === '/';
+  // 메인 페이지 여부
+  const isMainPage = pathname === "/";
 
-  // 드로어 열림 상태(메인 페이지에서만 의미 있게 사용됨)
+  // Drawer 열림 상태(메인 페이지에서만 의미)
   const [openDrawer, setOpenDrawer] = useState<boolean>(false);
+  // 내비게이션(페이지 이동) 시 애니메이션을 끄고 뒤로가기 모양을 유지하기 위한 플래그
+  const [disableAnimation, setDisableAnimation] = useState<boolean>(false);
 
-  // 메인 페이지를 벗어날 경우 자동으로 Drawer를 닫아준다(선택 사항)
+  // 메인 페이지를 벗어날 경우 자동으로 Drawer를 닫고 disableAnimation 활성화
   useEffect(() => {
     if (!isMainPage) {
       setOpenDrawer(false);
+      setDisableAnimation(true);
+    } else {
+      // 메인 페이지 복귀 시 애니메이션 복원
+      setDisableAnimation(false);
     }
   }, [isMainPage]);
 
@@ -31,64 +37,81 @@ const Header: React.FC = () => {
     e.stopPropagation();
 
     if (isMainPage) {
-      // 메인 페이지에서는 Drawer 열기/닫기
+      // 메인 페이지에서는 Drawer 토글 (애니메이션 사용)
       setOpenDrawer((prev) => !prev);
     } else {
-      // 메인 페이지가 아닐 때는 뒤로가기
+      // 내비게이션 시에는 disableAnimation을 활성화하고 뒤로가기
+      setDisableAnimation(true);
       router.back();
     }
   };
 
-  // 장바구니 버튼 클릭 시 이동
+  // 장바구니 버튼 클릭 시 내비게이션 전에 disableAnimation 활성화
   const handleNavigation = (path: string, e: MouseEvent) => {
     e.stopPropagation();
+    setDisableAnimation(true);
     router.push(path);
   };
 
-  // 메인 페이지가 아닐 때는 항상 'open' 클래스를 줘서 아이콘을 '뒤로가기' 형태처럼 보이게 만든다
-  const hamburgerButtonClass = isMainPage 
-    ? (openDrawer ? 'open' : '') 
-    : 'open';
+  // disableAnimation 플래그가 활성화되면 무조건 뒤로가기 모양("open")을 사용
+  const effectiveHamburgerClass = disableAnimation
+    ? "open"
+    : isMainPage
+    ? openDrawer
+      ? "open"
+      : ""
+    : "open";
 
   return (
     <header className="relative flex items-center justify-between px-6 py-3 h-12 bg-white">
-      {/* 왼쪽 영역: 메뉴 버튼 + (메인 페이지이면서 Drawer 닫힘 시) 플러스 버튼 */}
+      {/* 왼쪽 영역: 메뉴 버튼과 플러스 버튼 */}
       <div className="flex w-full items-center">
         <summary
-          className={`menu-button z-30 bg-contrast ${hamburgerButtonClass}`}
+          className={`menu-button z-30 ${accessibilityMode ? "bg-[#dadada]" : "bg-contrast"} ${effectiveHamburgerClass} ${disableAnimation ? "no-animation" : ""}`}
           aria-haspopup="dialog"
           aria-label="Open Menu"
           data-type="menu"
           role="button"
           onClick={handleHamburgerClick}
         >
-          <div className="menu-button__icon">
-            <div className="menu-button__bar menu-button__bar--1"></div>
-            <div className="menu-button__bar menu-button__bar--2"></div>
+          <div className="menu-button__icon-wrapper">
+            <div className="menu-button__icon">
+              <div className="menu-button__bar menu-button__bar--1"></div>
+              <div className="menu-button__bar menu-button__bar--2"></div>
+            </div>
           </div>
         </summary>
 
-        {/* 플러스 버튼: 메인 페이지에서 Drawer가 닫혀있을 때만 노출 */}
-        {isMainPage && !openDrawer && (
+        {/* 플러스 버튼: 메인 페이지이고 Drawer가 닫힌 상태이며 disableAnimation이 아닐 때 렌더링 */}
+        {isMainPage && !openDrawer && !disableAnimation && (
           <button className="ml-1 p-2 focus:outline-none">
             <FiPlus size={22} />
           </button>
         )}
       </div>
 
-      {/* 오른쪽 영역: 쇼핑카트 아이콘 */}
+      {/* 오른쪽 영역: 쇼핑카트 버튼 */}
       <div className="flex-shrink-0">
         <button
-          className={`p-2 focus:outline-none ${accessibilityMode ? 'bg-[#dadada]' : ''}`}
+          className={`p-2 focus:outline-none ${
+            accessibilityMode ? "bg-[#dadada]" : ""
+          }`}
           onClick={(e) => handleNavigation("/cart", e)}
         >
           <FiShoppingCart size={24} />
         </button>
       </div>
 
-      {/* 메인 페이지라면 Drawer 컴포넌트 렌더링 */}
+      {/* 메인 페이지일 때만 Drawer 렌더링 */}
       {isMainPage && (
-        <Drawer isOpen={openDrawer} onClose={() => setOpenDrawer(false)} />
+        <Drawer
+          isOpen={openDrawer}
+          onClose={() => {
+            setDisableAnimation(true);
+            setOpenDrawer(false);
+          }}
+          disableAnimation={disableAnimation} // Drawer에도 disableAnimation 전달
+        />
       )}
     </header>
   );


### PR DESCRIPTION
햄버거 버튼 깜박이는 문제를 해결했다. 처음엔 clip-path transition 때문인 줄 알았는데, 페이지 이동 시 헤더 상태가 초기화되면서 햄버거 버튼이 원래 모양으로 잠깐 돌아가는 게 원인이었다.

헤더 상태를 이동 중에도 '뒤로가기' 모양으로 유지하도록 disableAnimation을 활용해서 관리했고, clip-path 깜빡임은 overflow:hidden을 추가해서 방지했다.

단순 스타일 문제가 아니라 상태 관리도 영향을 줄 수 있음.
페이지 이동 중 상태가 초기화되지 않도록 하면 예상치 못한 깜빡임을 막을 수 있음.



해결 코드:

const handleNavigation = (path: string, e: MouseEvent) => {
  e.stopPropagation();
  setDisableAnimation(true); // 페이지 이동 중에도 햄버거 버튼이 뒤로가기 모양 유지되도록
  router.push(path);
};

// 항상 disableAnimation이 true면 'open'(뒤로가기 모양) 상태를 유지
const effectiveHamburgerClass = disableAnimation ? "open" : isMainPage ? openDrawer ? "open"  : "" : "open";

<summary
  className={`menu-button z-30 ${effectiveHamburgerClass} ${
    disableAnimation ? "no-animation" : ""
  }`}
  onClick={handleHamburgerClick}
>
  <div className="menu-button__icon-wrapper">
    <div className="menu-button__icon">
      <div className="menu-button__bar menu-button__bar--1"></div>
      <div className="menu-button__bar menu-button__bar--2"></div>
    </div>
  </div>
</summary>