### PR TITLE
🐛 스크롤 락 개선 및 헤더 고정 레이아웃 수정

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -138,13 +138,14 @@ const Home: React.FC = () => {
   );
 
   useEffect(() => {
-    if (gridState === "grid9" && openDrawer) {
-      console.log("grid9 - 스크롤 없애기");
+    if (openDrawer || (gridState === "grid9" && !isZoomMode)) {
       document.body.style.overflow = "hidden";
+      document.documentElement.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "auto";
+      document.documentElement.style.overflow = "auto";
     }
-  }, [gridState, openDrawer]);
+  }, [gridState, openDrawer, isZoomMode]);
   
 
   useLayoutEffect(() => {
@@ -174,7 +175,7 @@ const Home: React.FC = () => {
   }, [isZoomMode, selectedImage, selectedImageMounted, setZoomMode]);
 
   return (
-    <div className="min-h-screen flex flex-col justify-start items-center pt-14 p-4">
+    <div className="min-h-screen flex flex-col justify-start items-center pt-12 p-4">
       <AnimatePresence mode="wait">
         {!isZoomMode ? (
           <motion.div

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -94,7 +94,7 @@ const Header: React.FC = () => {
   }, [disableAnimation, isMainPage, openDrawer, isZoomMode, gridState]);
 
   return (
-    <header className="relative sticky top-0 flex items-center justify-between px-4 py-3 h-12 bg-transparent">
+    <header className="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 h-12 bg-transparent">
       <div className="flex w-full items-center">
         <summary
           className={`menu-button z-30 ${
@@ -136,6 +136,9 @@ const Header: React.FC = () => {
             </button>
           )}
       </div>
+
+      {/* 가운데 공간 확보를 위해 flex-1 추가 */}
+      <div className="flex-1"></div>
 
       <div className="flex-shrink-0">
         <button


### PR DESCRIPTION
[노트]

body에 overflow를 설정하면 스크롤이 막힐 줄 알았는데, 일부 브라우저에서는 html이 스크롤을 담당해서 적용되지 않는 경우가 있었다. 
특히 iOS Safari나 Firefox에서 body만 hidden으로 해도 html이 스크롤을 유지하는 문제가 있었다. 그래서 document.body와 document.documentElement(html) 모두 overflow를 변경해야 모든 환경에서 확실하게 스크롤을 막을 수 있었다. 
grid9에서는 기본적으로 스크롤을 막되, zoom 모드에서는 허용해야 했고, openDrawer가 열리면 무조건 막아야 해서 별도로 처리했다.

헤더는 sticky가 정상 작동하지 않아서 fixed로 변경했고, fixed로 바꾸면서 레이아웃이 깨지는 문제를 flex-1을 추가해 해결했다. 
flex-1을 적용해 가운데 공간을 확보하면서 cart 버튼이 오른쪽 끝에 고정되도록 조정했다. 
결과적으로 모든 상태에서 헤더가 올바르게 고정되고, 스크롤 제어도 정상적으로 동작하게 되었다.